### PR TITLE
Fix mouse support in `less`

### DIFF
--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -237,9 +237,7 @@ else
 fi
 
 # pager options
-# -X is needed to fix a bug with the --quit-if-one-screen feature in old
-# versions of less. Unfortunately, it also breaks mouse-wheel support.
-export LESS='-SRFX --tabs=4'
+export LESS='-SRF --tabs=4'
 
 if [ -x "$(command -v bat)" ]; then
   export PAGER='bat -p'


### PR DESCRIPTION
The -X flag breaks mouse-wheel support and it's unneeded for less>=530.
