### PR TITLE
Remove git message template

### DIFF
--- a/templates/git/commit-msg.txt
+++ b/templates/git/commit-msg.txt
@@ -1,11 +1,3 @@
-# If applied, this commit will...
 
-# Why is this change needed?
-Prior to this change,
-
-# How does it address the issue?
-This change
-
-# Provide links to any relevant tickets, articles or other resources
 
 # Co-authored-by:


### PR DESCRIPTION
This was useful, but now just gets in the way. I am in the habit of
writing commit messages in the right format, so don't need the extra
structure.
