### PR TITLE
ssh without 1password

### DIFF
--- a/templates/.ssh/config
+++ b/templates/.ssh/config
@@ -1,4 +1,8 @@
 {% if one_password_agent %}
 Host *
   IdentityAgent "{{ one_password_agent }}"
+{% else %}
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
 {% endif %}

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -288,6 +288,7 @@ alias npm='_nvm_init; npm'
 alias node='_nvm_init; node'
 
 
+{% if macos %}
 ########
 # macOS
 ########
@@ -300,6 +301,7 @@ alias hidefiles="defaults write com.apple.finder AppleShowAllFiles -bool false &
 export PATH="$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$PATH"
 
 
+{% endif %}
 {% if kraken %}
 ################
 # Work (Kraken)

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -300,6 +300,10 @@ alias hidefiles="defaults write com.apple.finder AppleShowAllFiles -bool false &
 # Prefer GNU tools over the MacOS BSD ones.
 export PATH="$HOMEBREW_PREFIX/opt/findutils/libexec/gnubin:$HOMEBREW_PREFIX/opt/gawk/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/grep/libexec/gnubin:$PATH"
 
+{% if not one_password_agent %}
+ssh-add --apple-use-keychain
+{% endif %}
+
 
 {% endif %}
 {% if kraken %}


### PR DESCRIPTION
- Store ssh key in keychain when not using 1Password
- Only include macOS-specific setup if using macOS
- Add ssh key to Apple keychain if not using 1Password
