### PR TITLE
Workaround being in a different directory

### DIFF
--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -179,7 +179,7 @@ function gswf(){
 }
 
 function gaf(){
-  git diff --name-only | fzf --multi --query="$@" | xargs git add
+  git diff --name-only --no-relative | fzf --multi --query="$@" | xargs git -C "$(git rev-parse --show-toplevel)" add
 }
 
 # Create a new PR in the origin repo


### PR DESCRIPTION
Before, `git diff` might be using the `relative` option, which would
only show changes in the current directory. This disables that option to
ensure we see *all* changed files, then ensures we are adding from the
correct directory (since the output of `git diff` will now be relative
to the repo root).
