### PR TITLE
Replace `exa` with `eza`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -88,7 +88,7 @@ def test_bin(session: nox.Session) -> None:
 
 BREW_PACKAGES = (
     'bat',
-    'exa',
+    'eza',
     'fzf',
     'less',
     'cantino/mcfly/mcfly',

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -256,10 +256,10 @@ alias reload!='. ~/.zshrc'
 
 alias local-ip="ifconfig | grep 'inet ' | grep -v 127.0.0.1 | awk '{print \$2}'"
 
-# ls & exa
+# ls & eza
 export LSCOLORS=gxfxhxdxcxegedabagacad
-if [ -x "$(command -v exa)" ]; then
-  alias ll="exa --long --header --group"
+if [ -x "$(command -v eza)" ]; then
+  alias ll="eza --long --header --group"
   alias la="ll --all"
 else
   alias ll='ls -lh'


### PR DESCRIPTION
`exa` is no longer maintained: https://github.com/ogham/exa/issues/1243
