### PR TITLE
Add a highlighted column in commit message editing

### DIFF
--- a/templates/vim/vimrc
+++ b/templates/vim/vimrc
@@ -45,6 +45,8 @@ colorscheme codedark
 " Wrap gitcommit file types at the appropriate length
 filetype indent plugin on
 
+autocmd BufEnter COMMIT_EDITMSG setlocal colorcolumn=+1
+
 " spelling
 :set spell
 :iabbrev amoutn amount


### PR DESCRIPTION
This makes it easier to see where line breaks should be to keep commit
messages to 72 characters wide.

![Screenshot 2024-03-21 at 23 05 08](https://github.com/samueljsb/config-files/assets/7549858/ae18b4a6-6995-4524-8423-ae0191fc148b)
