### PR TITLE
Add better colors for `git diff --color-moved`

### DIFF
--- a/templates/git/config
+++ b/templates/git/config
@@ -96,6 +96,10 @@
   commit = "yellow bold"
   new = "green bold"
   whitespace = "red reverse"
+  newMoved = "green dim"
+  newMovedAlternative = "green dim"
+  oldMoved = "red dim"
+  oldMovedAlternative = "red dim"
 
 [color "diff-highlight"]
   oldNormal = "red bold"


### PR DESCRIPTION
Stolen from <https://github.com/meshy/dotfiles/blob/524751623830558a0f00927e26ebd8671f24412d/gitconfig>.
