### PR TITLE
Remove Ruby from shell prompt

### DIFF
--- a/templates/starship.toml
+++ b/templates/starship.toml
@@ -102,6 +102,7 @@ symbol = " "
 
 [ruby]
 symbol = " "
+disabled = true
 
 [rust]
 symbol = " "


### PR DESCRIPTION
This turns up in a few places and it's distracting/annoying.
