### PR TITLE
zsh tab complete

### DIFF
--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -74,6 +74,8 @@ if [ -x "$(command -v atuin)" ]; then
   eval "$(atuin init zsh --disable-up-arrow)"
 fi
 
+autoload -U compinit; compinit
+
 
 ##########
 # editors

--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -46,10 +46,6 @@ setopt INC_APPEND_HISTORY SHARE_HISTORY  # adds history incrementally and share 
 setopt HIST_IGNORE_ALL_DUPS  # don't record dupes in history
 setopt HIST_REDUCE_BLANKS
 
-# don't expand aliases _before_ completion has finished
-#   like: git comm-[tab]
-setopt complete_aliases
-
 bindkey '^[^[[D' backward-word
 bindkey '^[^[[C' forward-word
 bindkey '^[[5D' beginning-of-line


### PR DESCRIPTION
- **Configure zsh tab-completions**
- **Remove `complete_aliases` option**
