### PR TITLE
Use `uv` in `nox` if it is available

### DIFF
--- a/templates/.zshrc
+++ b/templates/.zshrc
@@ -245,6 +245,8 @@ export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/startup.py"
 
 export MYPY_CACHE_DIR="$XDG_CACHE_HOME/mypy"
 
+export NOX_DEFAULT_VENV_BACKEND='uv|virtualenv'
+
 export PIP_REQUIRE_VIRTUALENV=1
 
 export PIPX_DEFAULT_PYTHON=python3.12


### PR DESCRIPTION
`uv` is much faster than the default `virtualenv`. Fall back to
`virtualenv` if `uv` is not present.
