### PR TITLE
Add a keyinding to reflow the current line

### DIFF
--- a/templates/helix/config.toml
+++ b/templates/helix/config.toml
@@ -22,3 +22,6 @@ display-inlay-hints = true
 
 [editor.whitespace.render]
 tab = "all"
+
+[keys.normal]
+"A-q" = ["extend_to_line_bounds", ":reflow"]


### PR DESCRIPTION
This is useful for git commit messages, because Helix does not
automatically hard-wrap at the line width, like vim does.
