### PR TITLE
Set line length for Python to 79 characters

### DIFF
--- a/templates/Code/User/settings.json
+++ b/templates/Code/User/settings.json
@@ -14,7 +14,7 @@
   "[python]": {
     "editor.formatOnSaveMode": "file",
     "editor.rulers": [
-      88
+      79
     ]
   },
   "[restructuredtext]": {


### PR DESCRIPTION
This is in accordance with PEP 8 and most of my project configs.
