### PR TITLE
Remove git blame extension

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -170,7 +170,6 @@ VS_CODE_EXTENSIONS = (
         'codezombiech.gitignore',
         'fabiospampinato.vscode-open-in-github',
         'sidneys1.gitconfig',
-        'waderyan.gitblame',
         # Python
         'charliermarsh.ruff',
         'lextudio.restructuredtext',


### PR DESCRIPTION
This doesn't work well and is built into VS Code now.
