### PR TITLE
Ensure `.git/info` directory exists if writing to it

### DIFF
--- a/bin/setup_aactivator.py
+++ b/bin/setup_aactivator.py
@@ -30,6 +30,11 @@ def main() -> int:
     os.chmod('.deactivate.sh', 0o600)
 
     if args.git_exclude:
+        try:
+            os.mkdir('.git/info')
+        except FileExistsError:
+            pass
+
         with open('.git/info/exclude', 'a') as fd:
             fd.write('.activate.sh\n')
             fd.write('.deactivate.sh\n')


### PR DESCRIPTION
Before this change, this script sometimes failed:

```console
$ setup-aactivator --git-exclude
Traceback (most recent call last):
  File "/Users/sam.searles-bryant/.local/bin/setup-aactivator", line 41, in <module>
    raise SystemExit(main())
                     ~~~~^^
  File "/Users/sam.searles-bryant/.local/bin/setup-aactivator", line 33, in main
    with open('.git/info/exclude', 'a') as fd:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '.git/info/exclude'
```

This change ensuers the `.git/info` directory exists before trying to
write a file inside it.
