### PR TITLE
Do not capture output when running `git push`

### DIFF
--- a/bin/git_push_all.py
+++ b/bin/git_push_all.py
@@ -48,7 +48,9 @@ def main() -> int:
     log_lines = _git('log', f'{args.base_ref}..', '--format=format:%D').split('\n')
 
     branches = _parse_branches(log_lines, args.base_ref, remotes)
-    _git('push', args.force_flag, '--atomic', 'origin', *branches)
+    subprocess.check_call(
+        ('git', 'push', args.force_flag, '--atomic', 'origin', *branches),
+    )
 
     return 0
 


### PR DESCRIPTION
Before this change, any failure to push caused an error, but the error
message was swallowed, which made it hard to diagnose. This change
ensures we do not capture the output from `git push` so it will be
visible.
