### PR TITLE
Fix `release-version` to handle hypoerlinked 'Unreleased' header

### DIFF
--- a/bin/release_version.py
+++ b/bin/release_version.py
@@ -18,7 +18,7 @@ def _update_files(version: str, date: datetime.date) -> None:
 
     for line in fileinput.input('CHANGELOG.md', inplace=True):
         print(line, end='')
-        if line == '## Unreleased\n':
+        if line in ('## Unreleased\n', '## [Unreleased]\n'):
             print('')
             print(f'## [{version}] - {date.isoformat()}')
 


### PR DESCRIPTION
Some projects make the 'Unreleased' header a link. Those were not
handled by the script and the new version header did not get added to
the changelog. This change ensures both linked and unlinked formats are
accounted for.
