### PR TITLE
Remove `trash` from Homebrew installs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -112,7 +112,6 @@ BREW_MACOS_PACKAGES = (
     'gawk',  # awk
     'gnu-sed',  # sed
     'grep',  # egrep, fgrep, grep
-    'trash',
 )
 
 


### PR DESCRIPTION
This is now provided in macOS.
